### PR TITLE
Hotfix/s3 dependency on stack creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # IDE
 .idea
 hardened-bastion.iml
+.terraform

--- a/example/bastion.tf
+++ b/example/bastion.tf
@@ -1,6 +1,6 @@
 provider "aws" {
-  shared_credentials_file = "/home/austin/.aws/credentials"
-  profile                 = "personal"
+  shared_credentials_file = "/home/dom/.aws/credentials"
+  profile                 = "personal-tfcli"
   region                  = "ap-southeast-2"
 }
 
@@ -28,26 +28,26 @@ data "local_file" "ssh_users" {
 
 module "bastion" {
   source   = "../"
-  vpc_id   = "vpc-a564cec2"  # The VPC ID into which you want to deploy this bastion
+  vpc_id   = "vpc-63d46406"  # The VPC ID into which you want to deploy this bastion
   vpc_cidr = "172.31.0.0/16" # The corresponding CIDR block for that VPC - the bastion will only be able to communicate with hosts inside it's VPC/CIDR block
 
   public_subnet_ids = [
-    "subnet-381e7871", # The public subnets in the VPC that the bastion can be created in
-    "subnet-458aff22",
-    "subnet-cf0cfa97",
+    "subnet-2fe45c58", # The public subnets in the VPC that the bastion can be created in
+    "subnet-f85fcc9d",
+    "subnet-a99bcaef",
   ]
 
-  secret_0_public_key           = "${file("/home/austin/.ssh/id_rsa.pub")}" # The SSH public key you want uploaded to EC2 as a keypair, if all else fails this will always have access
-  bastion_log_retention         = 14                                        # The number of days you want to retain logs that are centralised from the host
-  disable_root_user_ssh         = "true"                                    # Prevents the default sudo user from SSHing in
-  enable_ssh_port_knocking      = "true"                                    # Configures the system to require you broadcast a UDP packet to the host before it becomes visible on the internet
-  enable_ssh_tfa                = "false"                                   # Configures the system to require TFA as part of the SSH authentication
-  disable_bash_history          = "false"                                   # If enabled, configures the system not to record any user actions on the system
-  enable_ephemeral_ssh_sessions = "false"                                   # If enabled, at the end of the SSH session the host will terminate and another will come back in it's place
+  secret_0_public_key           = "${file("/home/dom/.ssh/id_rsa.pub")}" # The SSH public key you want uploaded to EC2 as a keypair, if all else fails this will always have access
+  bastion_log_retention         = 14                                     # The number of days you want to retain logs that are centralised from the host
+  disable_root_user_ssh         = "false"                                # Prevents the default sudo user from SSHing in
+  enable_ssh_port_knocking      = "false"                                # Configures the system to require you broadcast a UDP packet to the host before it becomes visible on the internet
+  enable_ssh_tfa                = "false"                                # Configures the system to require TFA as part of the SSH authentication
+  disable_bash_history          = "false"                                # If enabled, configures the system not to record any user actions on the system
+  enable_ephemeral_ssh_sessions = "false"                                # If enabled, at the end of the SSH session the host will terminate and another will come back in it's place
 
   # The range between which a SPA packet will be accepted
-  ssh_port_knocking_port_range_lower_bound = "62201"
-  ssh_port_knocking_port_range_upper_bound = "62209"
+  //  ssh_port_knocking_port_range_lower_bound = "62201"
+  //  ssh_port_knocking_port_range_upper_bound = "62209"
 
   ssh_users = "${data.local_file.ssh_users.content}" # This is the file that configures the Users on the system, note secrets for TFA/Port Knocking are only required if they're enabled above
 

--- a/example/bastion.tf
+++ b/example/bastion.tf
@@ -1,6 +1,6 @@
 provider "aws" {
-  shared_credentials_file = "/home/dom/.aws/credentials"
-  profile                 = "personal-tfcli"
+  shared_credentials_file = "/home/austin/.aws/credentials"
+  profile                 = "personal"
   region                  = "ap-southeast-2"
 }
 
@@ -28,22 +28,22 @@ data "local_file" "ssh_users" {
 
 module "bastion" {
   source   = "../"
-  vpc_id   = "vpc-63d46406"  # The VPC ID into which you want to deploy this bastion
+  vpc_id   = "vpc-a564cec2"  # The VPC ID into which you want to deploy this bastion
   vpc_cidr = "172.31.0.0/16" # The corresponding CIDR block for that VPC - the bastion will only be able to communicate with hosts inside it's VPC/CIDR block
 
   public_subnet_ids = [
-    "subnet-2fe45c58", # The public subnets in the VPC that the bastion can be created in
-    "subnet-f85fcc9d",
-    "subnet-a99bcaef",
+    "subnet-381e7871", # The public subnets in the VPC that the bastion can be created in
+    "subnet-458aff22",
+    "subnet-cf0cfa97",
   ]
 
-  secret_0_public_key           = "${file("/home/dom/.ssh/id_rsa.pub")}" # The SSH public key you want uploaded to EC2 as a keypair, if all else fails this will always have access
-  bastion_log_retention         = 14                                     # The number of days you want to retain logs that are centralised from the host
-  disable_root_user_ssh         = "true"                                # Prevents the default sudo user from SSHing in
-  enable_ssh_port_knocking      = "true"                                 # Configures the system to require you broadcast a UDP packet to the host before it becomes visible on the internet
-  enable_ssh_tfa                = "true"                                 # Configures the system to require TFA as part of the SSH authentication
-  disable_bash_history          = "false"                                # If enabled, configures the system not to record any user actions on the system
-  enable_ephemeral_ssh_sessions = "false"                                # If enabled, at the end of the SSH session the host will terminate and another will come back in it's place
+  secret_0_public_key           = "${file("/home/austin/.ssh/id_rsa.pub")}" # The SSH public key you want uploaded to EC2 as a keypair, if all else fails this will always have access
+  bastion_log_retention         = 14                                        # The number of days you want to retain logs that are centralised from the host
+  disable_root_user_ssh         = "true"                                    # Prevents the default sudo user from SSHing in
+  enable_ssh_port_knocking      = "true"                                    # Configures the system to require you broadcast a UDP packet to the host before it becomes visible on the internet
+  enable_ssh_tfa                = "false"                                   # Configures the system to require TFA as part of the SSH authentication
+  disable_bash_history          = "false"                                   # If enabled, configures the system not to record any user actions on the system
+  enable_ephemeral_ssh_sessions = "false"                                   # If enabled, at the end of the SSH session the host will terminate and another will come back in it's place
 
   # The range between which a SPA packet will be accepted
   ssh_port_knocking_port_range_lower_bound = "62201"

--- a/main.tf
+++ b/main.tf
@@ -89,10 +89,6 @@ data "template_file" "bootstrap_system_configuration" {
     environment     = "${var.environment}"
     payload_name    = "${aws_s3_bucket_object.playbook.key}"
   }
-
-  depends_on = [
-    "aws_s3_bucket_object.playbook",
-  ]
 }
 
 data "template_cloudinit_config" "bootstrap_config" {

--- a/main.tf
+++ b/main.tf
@@ -338,6 +338,10 @@ resource "aws_s3_bucket_object" "playbook" {
 
   source = "${path.module}/assets/ansible_playbook.zip"
   etag   = "${data.archive_file.playbook_payload.output_md5}"
+
+  depends_on = [
+    "aws_s3_bucket.bucket",
+  ]
 }
 
 resource "aws_s3_bucket_policy" "bucket_policy" {


### PR DESCRIPTION
## Proposed Changes
I encountered a bug deploying this for the first time. This was because in `main.tf`, an `aws_s3_object` did not have a `depends_on` block for the s3 bucket it was trying to upload to.